### PR TITLE
Duplicate IRC links in the footer

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -91,7 +91,6 @@
 
           <li><%= link_to "@mephux on Twitter", 'https://www.twitter.com/mephux', :target => '_blank' %></li>
           <li><%= link_to "freenode.net #snorby", 'irc://freenode.net/snorby', :target => '_blank' %></li>
-          <li><%= link_to "freenode.net #snorby", 'irc://freenode.net/snorby', :target => '_blank' %></li>
           <li><%= link_to "Mailing List", 'http://groups.google.com/group/snorby', :target => '_blank' %></li>
 
         </ul>


### PR DESCRIPTION
The footer contained a duplicate link to the freenode IRC server. I removed it.
